### PR TITLE
feat: use preview image during game load

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -56,6 +56,12 @@ h1 {
 section#game {
     min-height: 515px;
     margin-bottom: 35px;
+    transition: opacity 200ms;
+}
+
+section#game:empty {
+    background: url("./preview.png") center 46px no-repeat;
+    opacity: 0.5;
 }
 
 /* Text sections */


### PR DESCRIPTION
## Overview

Uses `:empty` to set up the `preview.png` added in #11 as the game element's background image.

### PR Checklist

-   [x] Fixes #3
-   [x] I have run this code to verify it works
-   ~[ ] This PR includes unit tests for the code change~
