### PR TITLE
feat: enhanced README.md development docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Choosing a modern JavaScript UI framework, Pokemon-style.
 This is a hacked-together fork of [FullScreenShenanigans/FullScreenPokemon](https://github.com/FullScreenShenanigans/FullScreenPokemon), which is itself very old code on the not-production-ready [EightBittr game engine](https://github.com/FullScreenShenanigans/EightBittr).
 No guarantees any of this stuff works.
 
+<!-- Development -->
+
 ## Development
 
 After [forking the repo from GitHub](https://help.github.com/articles/fork-a-repo):
@@ -28,7 +30,13 @@ yarn run compile
 ```
 
 -   `yarn run hydrate` creates a few auto-generated setup files locally.
--   `yarn run compile` builds source code with TypeScript
+-   `yarn run compile` builds source code to `lib/` with TypeScript
+
+> Tip: run `yarn compile -w` to keep TypeScript running in watch mode, so your output files stay up-to-date as you save source code.
+
+### Running Locally
+
+Once you've run the setup commands above, `lib/index.html` will contain a working file you can directly open in a browser locally, such as with `open lib/index.html` on Mac or `start lib/index.html` on Windows.
 
 ### Running Tests
 
@@ -40,3 +48,17 @@ Tests are written in [Mocha](https://github.com/mochajs/mocha) and [Chai](https:
 Their files are written using alongside source files under `src/` and named `*.test.ts?`.
 Whenever you add, remove, or rename a `*.test.t*` file under `src/`, `watch` will re-run `yarn run test:setup` to regenerate the list of static test files in `test/index.html`.
 You can open that file in a browser to debug through the tests, or run `yarn test:run` to run them in headless Chrome.
+
+### Production Builds
+
+```shell
+yarn run dist
+```
+
+After running the `dist` command, the `dist/` folder will contain project outputs optimized for running in production: i.e. versions of code that are concatenated into fewer files and minified.
+`dist/index.html` will be a more optimized version of `lib/index.html`.
+
+<!-- Maps -->
+<!-- /Maps -->
+
+<!-- /Development -->


### PR DESCRIPTION
## Overview

Adds information to the README.md about `lib/` and `dist/`, most notably opening mentioning `lib/index.html` as something you can open.

Also adds missing `<!-- Development -->` & `<!-- /Development -->` comments that are needed for `shenanigans-manager`'s `hydrate` command to refresh the file.

### PR Checklist

-   [x] This repo's side of: https://github.com/FullScreenShenanigans/EightBittr/issues/336
-   [x] I have run this code to verify it works
-   [x] This PR includes unit tests for the code change
