### PR TITLE
chore: ignore vim temporary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ dist/
 lib/
 node_modules/
 test/
+*~
+*.swp
+*.swo


### PR DESCRIPTION
## Overview

What does this PR do? Why?
- a small change to `.gitignore` to ignore temporary files generated by vim
- prevent these temporary files (*~, *.swp, *.swo) to be pushed
- this should not affect any feature/logic

### PR Checklist

-   [ ] Fixes #
-   [x] I have run this code to verify it works
-   [x] This PR includes unit tests for the code change
