### PR TITLE
fix: text selection not disabled around game area

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -16,7 +16,7 @@ body {
 header {
     height: 49px;
     overflow: hidden;
-t    -ms-user-select: none;
+    -ms-user-select: none;
     -moz-user-select: none;
     -webkit-user-select: none;
     user-select: none;

--- a/src/index.css
+++ b/src/index.css
@@ -57,8 +57,6 @@ section#game {
     min-height: 515px;
     margin-bottom: 35px;
     position: relative;
-    -ms-user-select: none;
-    -moz-user-select: none;
     -webkit-user-select: none;
     user-select: none;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -16,7 +16,7 @@ body {
 header {
     height: 49px;
     overflow: hidden;
-    -ms-user-select: none;
+t    -ms-user-select: none;
     -moz-user-select: none;
     -webkit-user-select: none;
     user-select: none;
@@ -57,6 +57,9 @@ section#game {
     min-height: 515px;
     margin-bottom: 35px;
     position: relative;
+    -ms-user-select: none;
+    -moz-user-select: none;
+    -webkit-user-select: none;
     user-select: none;
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -57,6 +57,7 @@ section#game {
     min-height: 515px;
     margin-bottom: 35px;
     position: relative;
+    user-select: none;
 }
 
 /* Menu sections */


### PR DESCRIPTION
## Overview

What does this PR do? Why?
- disable user text selection around the game area
- prevent scenarios where text selection is triggered due to long-tapping buttons on mobile

### PR Checklist

-   [x] Fixes #26 
-   [x] I have run this code to verify it works
-   [ ] This PR includes unit tests for the code change
